### PR TITLE
Release 1.2.0: share codes, catalog refs, copy link, FAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to RetroGameCabling are documented in this file.
 
+## [1.2.0]
+
+### Added
+
+- **Share setup** – Editor dialog to export a self-contained **`ccc2`** code (MessagePack, gzip, base64). Catalog nodes encode as **item id + delta** when smaller than a full embed. **Copy code**, **copy link** (`/editor#…`, respects Vite `BASE_URL`), and import from pasted code. Opening a share URL loads the diagram from the hash after the item catalog is available.
+- **`@msgpack/msgpack`** for the share wire payload.
+- **`buildSeedDataFromCatalogItem`** – Single source for default node data from the catalog (used on drag-drop and when decoding ref nodes).
+- **FAQ** route and related navigation updates.
+
+### Changed
+
+- **Sidebar drops** – New nodes store **`itemId`** so shares can resolve catalog defaults on import.
+
 ## [1.1.0]
 
 ### Added

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import NotFound from "@/pages/not-found";
 import Home from "@/pages/Home";
 import Editor from "@/pages/Editor";
+import FAQ from "@/pages/FAQ";
 
 function Router() {
   return (
@@ -12,6 +13,7 @@ function Router() {
       <Route path="/" component={Home} />
       <Route path="/editor" component={Editor} />
       <Route path="/editor/:id" component={Editor} />
+      <Route path="/faq" component={FAQ} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-background/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card/95 text-foreground shadow-xl shadow-black/20 backdrop-blur-md duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground ring-offset-background transition-colors hover:bg-muted/80 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight text-foreground', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/client/src/lib/catalogNodeDefaults.ts
+++ b/client/src/lib/catalogNodeDefaults.ts
@@ -1,0 +1,62 @@
+import type { z } from 'zod';
+import { itemSchema } from '@shared/schema';
+
+export type CatalogItem = z.infer<typeof itemSchema>;
+
+/**
+ * Default node `data` for a catalog item (matches Editor drop logic; no React callbacks).
+ * Callers attach `onDelete` / `onUpdate` after spread.
+ */
+export function buildSeedDataFromCatalogItem(itemData: CatalogItem): Record<string, unknown> {
+  let initialLabel = itemData.name;
+  let variantIndex = 0;
+  if (itemData.variants && itemData.variants.length > 0) {
+    initialLabel = itemData.variants[0].name;
+    variantIndex = 0;
+  }
+
+  const newNodeData: Record<string, unknown> = {
+    label: initialLabel,
+    category: itemData.category,
+    specs: itemData.specs,
+    itemId: itemData.id,
+  };
+
+  if (itemData.variants && itemData.variants.length > 0) {
+    newNodeData.variants = itemData.variants;
+    newNodeData.variantIndex = variantIndex;
+  }
+
+  if (
+    (itemData.category === 'console' || itemData.category === 'custom') &&
+    !itemData.specs?.isSVS &&
+    !itemData.specs?.isCustomSwitch &&
+    !itemData.specs?.isHDMISwitch &&
+    itemData.specs?.outputs &&
+    itemData.specs.outputs.length > 0
+  ) {
+    newNodeData.selectedOutput = itemData.specs.outputs[0];
+  }
+
+  if (itemData.specs?.isSVS === true || itemData.specs?.isCustomSwitch === true || itemData.specs?.isHDMISwitch === true) {
+    const defaultSignalType = itemData.specs?.isHDMISwitch === true ? 'hdmi' : 'ypbpr';
+    const initialInputs = itemData.specs?.initialInputs;
+    const initialOutputs = itemData.specs?.initialOutputs;
+    newNodeData.svsNumInputs = Array.isArray(initialInputs) ? initialInputs.length : 1;
+    newNodeData.svsNumOutputs = Array.isArray(initialOutputs) ? initialOutputs.length : 1;
+    newNodeData.svsInputs = Array.isArray(initialInputs) ? [...initialInputs] : [defaultSignalType];
+    newNodeData.svsOutputs = Array.isArray(initialOutputs) ? [...initialOutputs] : [defaultSignalType];
+  }
+
+  if (itemData.category === 'display' && itemData.specs?.customizableInputs === true) {
+    newNodeData.customInputs = [...(itemData.specs?.inputs || ['composite'])];
+  }
+
+  if (itemData.category === 'switch' && itemData.specs?.switchVariants?.length > 0) {
+    const firstVariant = itemData.specs.switchVariants[0];
+    newNodeData.switchVariantIndex = 0;
+    newNodeData.label = firstVariant.name;
+  }
+
+  return newNodeData;
+}

--- a/client/src/lib/shareCode.ts
+++ b/client/src/lib/shareCode.ts
@@ -1,0 +1,322 @@
+import { decode as msgpackDecode, encode as msgpackEncode } from '@msgpack/msgpack';
+import type { DiagramFile } from '@/lib/fileUtils';
+import { buildSeedDataFromCatalogItem, type CatalogItem } from '@/lib/catalogNodeDefaults';
+
+/** Gzip-compressed MessagePack wire v2 (catalog refs + deltas). */
+export const SHARE_CODE_PREFIX = 'ccc2';
+
+const OMIT_KEYS = new Set(['onDelete', 'onUpdate', '_updated', '_edgeUpdated']);
+
+function jsonReplacer(key: string, value: unknown): unknown {
+  if (OMIT_KEYS.has(key)) return undefined;
+  if (typeof value === 'function') return undefined;
+  return value;
+}
+
+function sanitizeDiagramForShare(diagram: DiagramFile): DiagramFile {
+  return JSON.parse(JSON.stringify(diagram, jsonReplacer)) as DiagramFile;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Drop React Flow runtime fields and edge styling that we recompute on load. */
+function compactDiagramForShare(diagram: DiagramFile): DiagramFile {
+  const data = diagram.data as Record<string, unknown> | undefined;
+  if (!data || typeof data !== 'object') return diagram;
+
+  const rawNodes = data.nodes;
+  const rawEdges = data.edges;
+  const nodes = Array.isArray(rawNodes)
+    ? rawNodes.map((n) => {
+        const node = n as Record<string, unknown>;
+        const pos = node.position as { x?: number; y?: number } | undefined;
+        const compact: Record<string, unknown> = {
+          id: node.id,
+          type: node.type,
+          position:
+            pos && typeof pos.x === 'number' && typeof pos.y === 'number'
+              ? { x: round2(pos.x), y: round2(pos.y) }
+              : node.position,
+          data: node.data,
+        };
+        if (node.parentNode != null) compact.parentNode = node.parentNode;
+        if (node.extent != null) compact.extent = node.extent;
+        if (typeof node.zIndex === 'number') compact.zIndex = node.zIndex;
+        if (node.hidden === true) compact.hidden = true;
+        return compact;
+      })
+    : [];
+
+  const edges = Array.isArray(rawEdges)
+    ? rawEdges.map((e) => {
+        const edge = e as Record<string, unknown>;
+        const compact: Record<string, unknown> = {
+          id: edge.id,
+          source: edge.source,
+          target: edge.target,
+        };
+        if (edge.sourceHandle) compact.sourceHandle = edge.sourceHandle;
+        if (edge.targetHandle) compact.targetHandle = edge.targetHandle;
+        if (edge.type && edge.type !== 'default') compact.type = edge.type;
+        const d = edge.data as Record<string, unknown> | undefined;
+        if (d && d.outputType != null) {
+          compact.data = { outputType: d.outputType };
+        }
+        return compact;
+      })
+    : [];
+
+  const next: Record<string, unknown> = { nodes, edges };
+  const vp = data.viewport as { x?: number; y?: number; zoom?: number } | undefined;
+  if (vp && typeof vp === 'object') {
+    const zx = typeof vp.x === 'number' ? round2(vp.x) : vp.x;
+    const zy = typeof vp.y === 'number' ? round2(vp.y) : vp.y;
+    const zz = typeof vp.zoom === 'number' ? Math.round(vp.zoom * 1000) / 1000 : vp.zoom;
+    const isDefault = zx === 0 && zy === 0 && (zz === 1 || zz === undefined);
+    if (!isDefault) {
+      next.viewport = { x: zx, y: zy, zoom: zz };
+    }
+  }
+
+  return { name: diagram.name, data: next };
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+  let base64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  while (base64.length % 4) base64 += '=';
+  const bin = atob(base64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function gzipBytes(input: Uint8Array): Promise<Uint8Array> {
+  if (typeof CompressionStream === 'undefined') {
+    throw new Error('This browser does not support sharing (CompressionStream missing).');
+  }
+  const stream = new Blob([input]).stream().pipeThrough(new CompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function gunzipBytes(input: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream === 'undefined') {
+    throw new Error('This browser does not support importing shares (DecompressionStream missing).');
+  }
+  const stream = new Blob([input]).stream().pipeThrough(new DecompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function computeDelta(actual: Record<string, unknown>, defaults: Record<string, unknown>): Record<string, unknown> {
+  const delta: Record<string, unknown> = {};
+  for (const key of Object.keys(actual)) {
+    if (OMIT_KEYS.has(key)) continue;
+    if (!(key in defaults)) {
+      delta[key] = actual[key];
+      continue;
+    }
+    if (!deepEqual(actual[key], defaults[key])) {
+      delta[key] = actual[key];
+    }
+  }
+  return delta;
+}
+
+function wireEdgesFromCompact(edges: unknown[]): Array<Record<string, unknown>> {
+  if (!Array.isArray(edges)) return [];
+  return edges.map((e) => {
+    const edge = e as Record<string, unknown>;
+    const o: Record<string, unknown> = { i: edge.id, s: edge.source, t: edge.target };
+    if (edge.sourceHandle) o.h = edge.sourceHandle;
+    if (edge.targetHandle) o.H = edge.targetHandle;
+    const d = edge.data as Record<string, unknown> | undefined;
+    if (d && d.outputType != null) o.o = d.outputType;
+    return o;
+  });
+}
+
+function parseWireEdges(eds: unknown): unknown[] {
+  if (!Array.isArray(eds)) return [];
+  return eds.map((raw) => {
+    const e = raw as Record<string, unknown>;
+    const edge: Record<string, unknown> = { id: e.i, source: e.s, target: e.t };
+    if (e.h) edge.sourceHandle = e.h;
+    if (e.H) edge.targetHandle = e.H;
+    if (e.o != null) edge.data = { outputType: e.o };
+    return edge;
+  });
+}
+
+function viewportToWire(vp: unknown): [number, number, number] | undefined {
+  if (!vp || typeof vp !== 'object') return undefined;
+  const v = vp as { x?: number; y?: number; zoom?: number };
+  const zx = typeof v.x === 'number' ? round2(v.x) : 0;
+  const zy = typeof v.y === 'number' ? round2(v.y) : 0;
+  const zz = typeof v.zoom === 'number' ? Math.round(v.zoom * 1000) / 1000 : 1;
+  if (zx === 0 && zy === 0 && zz === 1) return undefined;
+  return [zx, zy, zz];
+}
+
+function wireToViewport(w: unknown): Record<string, number> | undefined {
+  if (!Array.isArray(w) || w.length < 3) return undefined;
+  return { x: Number(w[0]), y: Number(w[1]), zoom: Number(w[2]) };
+}
+
+function encodeNodesWire(
+  nodes: unknown[],
+  itemsById: Map<number, CatalogItem>,
+): unknown[] {
+  if (!Array.isArray(nodes)) return [];
+  const out: unknown[] = [];
+
+  for (const n of nodes) {
+    const node = n as Record<string, unknown>;
+    const data = (node.data || {}) as Record<string, unknown>;
+    const pos = node.position as { x?: number; y?: number };
+    const px = typeof pos?.x === 'number' ? round2(pos.x) : 0;
+    const py = typeof pos?.y === 'number' ? round2(pos.y) : 0;
+    const flowId = String(node.id ?? '');
+    const itemId = typeof data.itemId === 'number' ? data.itemId : undefined;
+    const item = itemId != null ? itemsById.get(itemId) : undefined;
+
+    const fullPayload = ['f', node] as unknown[];
+
+    if (!item) {
+      out.push(fullPayload);
+      continue;
+    }
+
+    if (!deepEqual(data.specs, item.specs)) {
+      out.push(fullPayload);
+      continue;
+    }
+
+    const defaults = buildSeedDataFromCatalogItem(item) as Record<string, unknown>;
+    const delta = computeDelta(data, defaults);
+    const deltaObj = Object.keys(delta).length ? delta : null;
+    const refPayload = ['r', flowId, itemId, px, py, deltaObj] as unknown[];
+
+    if (msgpackEncode(refPayload).byteLength <= msgpackEncode(fullPayload).byteLength) {
+      out.push(refPayload);
+    } else {
+      out.push(fullPayload);
+    }
+  }
+
+  return out;
+}
+
+function decodeNodesWire(nds: unknown, itemsById: Map<number, CatalogItem>): unknown[] {
+  if (!Array.isArray(nds)) return [];
+
+  return nds.map((entry) => {
+    if (!Array.isArray(entry) || entry.length < 2) {
+      throw new Error('Invalid share: bad node entry.');
+    }
+    const tag = entry[0];
+    if (tag === 'f') {
+      const n = entry[1];
+      if (!n || typeof n !== 'object') throw new Error('Invalid share: full node payload.');
+      return n;
+    }
+    if (tag === 'r') {
+      if (entry.length < 6) throw new Error('Invalid share: ref node too short.');
+      const flowId = String(entry[1]);
+      const catalogId = Number(entry[2]);
+      const px = Number(entry[3]);
+      const py = Number(entry[4]);
+      const deltaRaw = entry[5];
+      const item = itemsById.get(catalogId);
+      if (!item) {
+        throw new Error(`Invalid share: unknown catalog item id ${catalogId}.`);
+      }
+      const defaults = buildSeedDataFromCatalogItem(item) as Record<string, unknown>;
+      const delta =
+        deltaRaw && typeof deltaRaw === 'object' && !Array.isArray(deltaRaw)
+          ? (deltaRaw as Record<string, unknown>)
+          : {};
+      const merged = { ...defaults, ...delta };
+      return {
+        id: flowId,
+        type: 'equipment',
+        position: { x: px, y: py },
+        data: merged,
+      };
+    }
+    throw new Error('Invalid share: unknown node tag.');
+  });
+}
+
+export async function encodeDiagramShareCode(
+  diagram: DiagramFile,
+  items: CatalogItem[],
+): Promise<string> {
+  const clean = sanitizeDiagramForShare(diagram);
+  const compact = compactDiagramForShare(clean);
+  const data = compact.data as Record<string, unknown>;
+  const itemsById = new Map(items.map((i) => [i.id, i]));
+
+  const nds = encodeNodesWire(data.nodes ?? [], itemsById);
+  const eds = wireEdgesFromCompact(data.edges ?? []);
+  const vp = viewportToWire(data.viewport);
+
+  const wire = {
+    v: 2 as const,
+    n: compact.name,
+    ...(vp ? { vp } : {}),
+    nds,
+    eds,
+  };
+
+  const packed = msgpackEncode(wire);
+  const gz = await gzipBytes(packed);
+  return SHARE_CODE_PREFIX + bytesToBase64Url(gz);
+}
+
+export async function decodeDiagramShareCode(
+  code: string,
+  items: CatalogItem[],
+): Promise<DiagramFile> {
+  const trimmed = code.trim().replace(/^#/, '');
+  if (!trimmed.startsWith(SHARE_CODE_PREFIX)) {
+    throw new Error(`Not a valid setup code (must start with ${SHARE_CODE_PREFIX}).`);
+  }
+  const b64 = trimmed.slice(SHARE_CODE_PREFIX.length);
+  if (!b64) throw new Error('Setup code is empty.');
+  const compressed = base64UrlToBytes(b64);
+  const raw = await gunzipBytes(compressed);
+  const doc = msgpackDecode(raw) as Record<string, unknown>;
+
+  if (Number(doc?.v) !== 2 || typeof doc.n !== 'string') {
+    throw new Error('Decoded data is not a valid diagram (wrong format).');
+  }
+
+  const itemsById = new Map(items.map((i) => [i.id, i]));
+  const nodes = decodeNodesWire(doc.nds, itemsById);
+  const edges = parseWireEdges(doc.eds);
+  const viewport = wireToViewport(doc.vp);
+
+  const flow: Record<string, unknown> = { nodes, edges };
+  if (viewport) flow.viewport = viewport;
+
+  return { name: doc.n, data: flow };
+}
+
+export type { CatalogItem } from '@/lib/catalogNodeDefaults';

--- a/client/src/pages/Editor.tsx
+++ b/client/src/pages/Editor.tsx
@@ -22,10 +22,12 @@ import CustomEdge from '@/components/CustomEdge';
 import { useLocation, useRoute } from 'wouter';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Save, ArrowLeft, Download, Share2, Upload, FileText, Grid3X3 } from 'lucide-react';
+import { Save, ArrowLeft, Share2, Upload, FileText, Grid3X3, Copy, Link2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { Link } from 'wouter';
 import { saveFile, loadFile, loadFileFromRecent, type DiagramFile } from '@/lib/fileUtils';
+import { encodeDiagramShareCode, decodeDiagramShareCode, SHARE_CODE_PREFIX } from '@/lib/shareCode';
+import { buildSeedDataFromCatalogItem } from '@/lib/catalogNodeDefaults';
 import { normalizeSignalType } from '@/lib/utils';
 import { useItems } from '@/hooks/use-items';
 import {
@@ -36,6 +38,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 
 // Register custom node types with edges access
 // Pass all edges - CustomNode will filter them internally for better memoization
@@ -206,6 +216,10 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
   const [reactFlowInstance, setReactFlowInstance] = useState<any>(null);
   const [diagramName, setDiagramName] = useState(initialDiagramName || 'Untitled Setup');
   const [snapToGridEnabled, setSnapToGridEnabled] = useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [shareExportText, setShareExportText] = useState('');
+  const [shareExportBusy, setShareExportBusy] = useState(false);
+  const [shareImportText, setShareImportText] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [shouldFitView, setShouldFitView] = useState(true);
   const needsFitViewAfterLoadRef = useRef(false);
@@ -492,6 +506,24 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
     });
   }, [getOutputColor, handleDeleteEdge]);
 
+  const applyDiagram = useCallback(
+    (diagram: DiagramFile) => {
+      setDiagramName(diagram.name);
+      const flow = diagram.data;
+      if (flow) {
+        const nodesWithDelete = (flow.nodes || []).map((node: any) => ({
+          ...node,
+          data: { ...node.data, onDelete: handleDeleteNode, onUpdate: handleUpdateNode },
+        }));
+        setNodes(nodesWithDelete);
+        const processedEdges = processEdgesWithColors(flow.edges || [], nodesWithDelete);
+        setEdges(processedEdges);
+        needsFitViewAfterLoadRef.current = true;
+      }
+    },
+    [setNodes, setEdges, handleDeleteNode, handleUpdateNode, processEdgesWithColors],
+  );
+
   // Call fitView after load when instance is ready - use method with explicit nodes and delay for DOM to update
   useEffect(() => {
     if (!reactFlowInstance || !needsFitViewAfterLoadRef.current || nodes.length === 0) return;
@@ -507,21 +539,42 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
     if (initialDiagramName) {
       const diagram = loadFileFromRecent(initialDiagramName);
       if (diagram) {
-        setDiagramName(diagram.name);
-        const flow = diagram.data;
-        if (flow) {
-          const nodesWithDelete = (flow.nodes || []).map((node: any) => ({
-            ...node,
-            data: { ...node.data, onDelete: handleDeleteNode, onUpdate: handleUpdateNode },
-          }));
-          setNodes(nodesWithDelete);
-          const processedEdges = processEdgesWithColors(flow.edges || [], nodesWithDelete);
-          setEdges(processedEdges);
-          needsFitViewAfterLoadRef.current = true;
-        }
+        applyDiagram(diagram);
       }
     }
-  }, [initialDiagramName, setNodes, setEdges, handleDeleteNode, handleUpdateNode, processEdgesWithColors]);
+  }, [initialDiagramName, applyDiagram]);
+
+  const shareFromHashDoneRef = useRef(false);
+  useEffect(() => {
+    if (shareFromHashDoneRef.current) return;
+    const raw = window.location.hash.replace(/^#/, '');
+    if (!raw.startsWith(SHARE_CODE_PREFIX)) return;
+    if (items == null) return;
+    shareFromHashDoneRef.current = true;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const diagram = await decodeDiagramShareCode(raw, items);
+        if (cancelled) return;
+        applyDiagram(diagram);
+        window.history.replaceState(null, '', window.location.pathname + window.location.search);
+        toast({
+          title: 'Loaded from link',
+          description: `Opened ${diagram.name}`,
+        });
+      } catch {
+        shareFromHashDoneRef.current = false;
+        toast({
+          title: 'Invalid share link',
+          description: 'The URL fragment could not be decoded as a setup.',
+          variant: 'destructive',
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [applyDiagram, toast, items]);
 
   // Handle keyboard delete for nodes and edges
   useEffect(() => {
@@ -873,61 +926,11 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
     if (!reactFlowInstance) return;
     const position = reactFlowInstance.screenToFlowPosition({ x, y });
       setNodes((nds) => {
-        // Determine initial label: use first variant if available, otherwise use base name
-        let initialLabel = itemData.name;
-        let variantIndex = 0;
-        if (itemData.variants && itemData.variants.length > 0) {
-          initialLabel = itemData.variants[0].name;
-          variantIndex = 0;
-        }
-        
-        const newNodeData: any = { 
-          label: initialLabel, 
-          category: itemData.category,
-          specs: itemData.specs,
+        const newNodeData: any = {
+          ...buildSeedDataFromCatalogItem(itemData),
           onDelete: handleDeleteNode,
           onUpdate: handleUpdateNode,
         };
-        
-        // Store variants data if available
-        if (itemData.variants && itemData.variants.length > 0) {
-          newNodeData.variants = itemData.variants;
-          newNodeData.variantIndex = variantIndex;
-        }
-        
-        // Initialize selectedOutput for consoles and custom items (use first available output)
-        if ((itemData.category === 'console' || itemData.category === 'custom') && 
-            !itemData.specs?.isSVS && 
-            !itemData.specs?.isCustomSwitch && 
-            !itemData.specs?.isHDMISwitch &&
-            itemData.specs?.outputs && 
-            itemData.specs.outputs.length > 0) {
-          newNodeData.selectedOutput = itemData.specs.outputs[0];
-        }
-        
-        // Initialize SVS/Custom Switch/HDMI Switch configuration if it's scalable
-        if (itemData.specs?.isSVS === true || itemData.specs?.isCustomSwitch === true || itemData.specs?.isHDMISwitch === true) {
-          const defaultSignalType = itemData.specs?.isHDMISwitch === true ? 'hdmi' : 'ypbpr';
-          const initialInputs = itemData.specs?.initialInputs;
-          const initialOutputs = itemData.specs?.initialOutputs;
-          newNodeData.svsNumInputs = Array.isArray(initialInputs) ? initialInputs.length : 1;
-          newNodeData.svsNumOutputs = Array.isArray(initialOutputs) ? initialOutputs.length : 1;
-          newNodeData.svsInputs = Array.isArray(initialInputs) ? [...initialInputs] : [defaultSignalType];
-          newNodeData.svsOutputs = Array.isArray(initialOutputs) ? [...initialOutputs] : [defaultSignalType];
-        }
-        
-        // Initialize customizable inputs for Custom TV (display with customizableInputs)
-        if (itemData.category === 'display' && itemData.specs?.customizableInputs === true) {
-          newNodeData.customInputs = [...(itemData.specs?.inputs || ['composite'])];
-        }
-        
-        // Initialize switch variant for switches with switchVariants (e.g. Extron Crosspoint)
-        if (itemData.category === 'switch' && itemData.specs?.switchVariants?.length > 0) {
-          const firstVariant = itemData.specs.switchVariants[0];
-          newNodeData.switchVariantIndex = 0;
-          newNodeData.label = firstVariant.name;
-        }
-        
         const newNode = {
           id: getNextNodeId(nds),
           type: 'equipment',
@@ -941,7 +944,7 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
       description: `Added ${itemData.name} to the canvas.`,
       duration: 1500,
     });
-  }, [reactFlowInstance, setNodes, toast, handleDeleteNode]);
+  }, [reactFlowInstance, setNodes, toast, handleDeleteNode, handleUpdateNode]);
 
 
   const onDrop = useCallback(
@@ -966,61 +969,11 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
       });
 
       setNodes((nds) => {
-        // Determine initial label: use first variant if available, otherwise use base name
-        let initialLabel = itemData.name;
-        let variantIndex = 0;
-        if (itemData.variants && itemData.variants.length > 0) {
-          initialLabel = itemData.variants[0].name;
-          variantIndex = 0;
-        }
-        
-        const newNodeData: any = { 
-          label: initialLabel, 
-          category: itemData.category,
-          specs: itemData.specs,
+        const newNodeData: any = {
+          ...buildSeedDataFromCatalogItem(itemData),
           onDelete: handleDeleteNode,
           onUpdate: handleUpdateNode,
         };
-        
-        // Store variants data if available
-        if (itemData.variants && itemData.variants.length > 0) {
-          newNodeData.variants = itemData.variants;
-          newNodeData.variantIndex = variantIndex;
-        }
-        
-        // Initialize selectedOutput for consoles and custom items (use first available output)
-        if ((itemData.category === 'console' || itemData.category === 'custom') && 
-            !itemData.specs?.isSVS && 
-            !itemData.specs?.isCustomSwitch && 
-            !itemData.specs?.isHDMISwitch &&
-            itemData.specs?.outputs && 
-            itemData.specs.outputs.length > 0) {
-          newNodeData.selectedOutput = itemData.specs.outputs[0];
-        }
-        
-        // Initialize SVS/Custom Switch/HDMI Switch configuration if it's scalable
-        if (itemData.specs?.isSVS === true || itemData.specs?.isCustomSwitch === true || itemData.specs?.isHDMISwitch === true) {
-          const defaultSignalType = itemData.specs?.isHDMISwitch === true ? 'hdmi' : 'ypbpr';
-          const initialInputs = itemData.specs?.initialInputs;
-          const initialOutputs = itemData.specs?.initialOutputs;
-          newNodeData.svsNumInputs = Array.isArray(initialInputs) ? initialInputs.length : 1;
-          newNodeData.svsNumOutputs = Array.isArray(initialOutputs) ? initialOutputs.length : 1;
-          newNodeData.svsInputs = Array.isArray(initialInputs) ? [...initialInputs] : [defaultSignalType];
-          newNodeData.svsOutputs = Array.isArray(initialOutputs) ? [...initialOutputs] : [defaultSignalType];
-        }
-        
-        // Initialize customizable inputs for Custom TV (display with customizableInputs)
-        if (itemData.category === 'display' && itemData.specs?.customizableInputs === true) {
-          newNodeData.customInputs = [...(itemData.specs?.inputs || ['composite'])];
-        }
-        
-        // Initialize switch variant for switches with switchVariants (e.g. Extron Crosspoint)
-        if (itemData.category === 'switch' && itemData.specs?.switchVariants?.length > 0) {
-          const firstVariant = itemData.specs.switchVariants[0];
-          newNodeData.switchVariantIndex = 0;
-          newNodeData.label = firstVariant.name;
-        }
-        
         const newNode = {
           id: getNextNodeId(nds),
           type,
@@ -1065,18 +1018,7 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
       setIsLoading(true);
       const diagram = await loadFile();
       if (diagram) {
-        setDiagramName(diagram.name);
-        const flow = diagram.data;
-        if (flow) {
-          const nodesWithDelete = (flow.nodes || []).map((node: any) => ({
-            ...node,
-            data: { ...node.data, onDelete: handleDeleteNode, onUpdate: handleUpdateNode },
-          }));
-          setNodes(nodesWithDelete);
-          const processedEdges = processEdgesWithColors(flow.edges || [], nodesWithDelete);
-          setEdges(processedEdges);
-          needsFitViewAfterLoadRef.current = true;
-        }
+        applyDiagram(diagram);
         toast({ title: "Loaded!", description: `Opened ${diagram.name}` });
         setLocation('/editor');
       }
@@ -1098,18 +1040,7 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
       if (!res.ok) throw new Error("Failed to load example");
       const diagram: DiagramFile = await res.json();
       
-      setDiagramName(diagram.name);
-      const flow = diagram.data;
-      if (flow) {
-        const nodesWithDelete = (flow.nodes || []).map((node: any) => ({
-          ...node,
-          data: { ...node.data, onDelete: handleDeleteNode, onUpdate: handleUpdateNode },
-        }));
-        setNodes(nodesWithDelete);
-        const processedEdges = processEdgesWithColors(flow.edges || [], nodesWithDelete);
-        setEdges(processedEdges);
-        needsFitViewAfterLoadRef.current = true;
-      }
+      applyDiagram(diagram);
       toast({ title: "Example Loaded!", description: `Opened ${diagram.name}` });
       setLocation('/editor');
     } catch (error) {
@@ -1120,6 +1051,87 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
       });
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!shareDialogOpen || !reactFlowInstance) return;
+    setShareExportBusy(true);
+    setShareExportText('');
+    let cancelled = false;
+    void (async () => {
+      try {
+        const flow = reactFlowInstance.toObject();
+        const diagramData: DiagramFile = { name: diagramName, data: flow };
+        const code = await encodeDiagramShareCode(diagramData, items ?? []);
+        if (!cancelled) setShareExportText(code);
+      } catch (e: unknown) {
+        if (!cancelled) {
+          setShareExportText('');
+          toast({
+            variant: 'destructive',
+            title: 'Could not create share code',
+            description: e instanceof Error ? e.message : 'Unknown error',
+          });
+        }
+      } finally {
+        if (!cancelled) setShareExportBusy(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [shareDialogOpen, reactFlowInstance, diagramName, toast, items]);
+
+  const shareExportUrl = useMemo(() => {
+    if (!shareExportText || shareExportBusy || typeof window === 'undefined') return '';
+    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+    const path = base ? `${base}/editor` : '/editor';
+    return `${window.location.origin}${path}#${shareExportText}`;
+  }, [shareExportText, shareExportBusy]);
+
+  const handleImportFromShareCode = async () => {
+    try {
+      const diagram = await decodeDiagramShareCode(shareImportText, items ?? []);
+      applyDiagram(diagram);
+      setShareDialogOpen(false);
+      setShareImportText('');
+      setLocation('/editor');
+      toast({ title: 'Setup loaded', description: diagram.name });
+    } catch (e: unknown) {
+      toast({
+        variant: 'destructive',
+        title: 'Invalid setup code',
+        description: e instanceof Error ? e.message : 'Decode failed',
+      });
+    }
+  };
+
+  const handleCopyShareCode = async () => {
+    if (!shareExportText) return;
+    try {
+      await navigator.clipboard.writeText(shareExportText);
+      toast({ title: 'Copied', description: 'Setup code is on the clipboard.' });
+    } catch {
+      toast({
+        variant: 'destructive',
+        title: 'Copy failed',
+        description: 'Select the code and copy manually, or check site permissions.',
+      });
+    }
+  };
+
+  const handleCopyShareUrl = async () => {
+    if (!shareExportUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareExportUrl);
+      toast({ title: 'Copied', description: 'Share link is on the clipboard.' });
+    } catch {
+      toast({
+        variant: 'destructive',
+        title: 'Copy failed',
+        description: 'Select the link and copy manually, or check site permissions.',
+      });
     }
   };
 
@@ -1210,6 +1222,18 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            <Button
+              type="button"
+              onClick={() => setShareDialogOpen(true)}
+              disabled={isLoading || !reactFlowInstance}
+              variant="outline"
+              size="sm"
+              className="bg-card/90 backdrop-blur-md border-border hover:bg-muted"
+              title="Copy or paste a compact setup code"
+            >
+              <Share2 className="w-4 h-4 md:mr-2" />
+              <span className="hidden md:inline">Share</span>
+            </Button>
             <Button 
               onClick={handleLoad}
               disabled={isLoading}
@@ -1277,7 +1301,82 @@ function EditorContent({ diagramName: initialDiagramName }: { diagramName?: stri
         </div>
       </div>
 
-
+      <Dialog
+        open={shareDialogOpen}
+        onOpenChange={(open) => {
+          setShareDialogOpen(open);
+          if (!open) setShareImportText('');
+        }}
+      >
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto ring-1 ring-border/40">
+          <DialogHeader>
+            <DialogTitle className="font-display uppercase tracking-wide">Share setup</DialogTitle>
+            <DialogDescription>
+              Paste the code or use the link (opens the editor with the setup in the URL hash).
+              Very long links may be truncated in some chat apps—use the raw code if that happens.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-sm font-medium">Your code</p>
+              <textarea
+                readOnly
+                value={shareExportBusy ? 'Generating…' : shareExportText}
+                rows={5}
+                className="w-full resize-y rounded-md border border-border bg-muted/25 px-3 py-2 font-mono text-[11px] leading-relaxed text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              <p className="text-sm font-medium">Share link</p>
+              <textarea
+                readOnly
+                value={shareExportBusy ? 'Generating…' : shareExportUrl}
+                rows={3}
+                className="w-full resize-y rounded-md border border-border bg-muted/25 px-3 py-2 font-mono text-[11px] leading-relaxed text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={handleCopyShareCode}
+                  disabled={shareExportBusy || !shareExportText}
+                >
+                  <Copy className="mr-2 h-4 w-4" />
+                  Copy code
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={handleCopyShareUrl}
+                  disabled={shareExportBusy || !shareExportUrl}
+                >
+                  <Link2 className="mr-2 h-4 w-4" />
+                  Copy link
+                </Button>
+              </div>
+            </div>
+            <div className="h-px bg-border" />
+            <div className="space-y-2">
+              <p className="text-sm font-medium">Import from code</p>
+              <textarea
+                value={shareImportText}
+                onChange={(e) => setShareImportText(e.target.value)}
+                placeholder={`Paste a setup code (starts with ${SHARE_CODE_PREFIX}…)`}
+                rows={5}
+                className="w-full resize-y rounded-md border border-border bg-muted/25 px-3 py-2 font-mono text-[11px] leading-relaxed text-foreground placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setShareDialogOpen(false)}>
+              Close
+            </Button>
+            <Button type="button" onClick={handleImportFromShareCode} disabled={!shareImportText.trim()}>
+              Load from code
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -1,0 +1,132 @@
+import { Link } from "wouter";
+import { ArrowLeft, HelpCircle } from "lucide-react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+export default function FAQ() {
+  return (
+    <div className="min-h-screen bg-background text-foreground font-sans">
+      <div className="container mx-auto px-6 py-12 max-w-2xl">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-8 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Home
+        </Link>
+
+        <div className="flex items-center gap-3 mb-10">
+          <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center">
+            <HelpCircle className="w-6 h-6 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-display font-bold">Frequently Asked Questions</h1>
+            <p className="text-muted-foreground mt-1">Tips and tricks for the diagram editor</p>
+          </div>
+        </div>
+
+        <Accordion type="single" collapsible className="space-y-2">
+          <AccordionItem value="multi-select" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              How do I select multiple nodes at once?
+            </AccordionTrigger>
+            <AccordionContent>
+              Hold <kbd className="px-1.5 py-0.5 rounded bg-muted text-xs font-mono">Ctrl</kbd> (Windows/Linux) or{" "}
+              <kbd className="px-1.5 py-0.5 rounded bg-muted text-xs font-mono">⌘ Cmd</kbd> (Mac) and click on nodes to add them to your selection. You can then move or delete them together. Click on empty canvas to deselect.
+            </AccordionContent>
+          </AccordionItem>
+
+          <AccordionItem value="snap-grid" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              What is the snap-to-grid feature?
+            </AccordionTrigger>
+            <AccordionContent>
+              The grid toggle (grid icon in the toolbar) switches between free-form placement and grid-aligned mode. When enabled, nodes snap to a 20×20 grid as you drag them, and the background shows visible grid lines to help you align components neatly. Great for tidy diagrams.
+            </AccordionContent>
+          </AccordionItem>
+
+          <AccordionItem value="connecting" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              How do I connect components?
+            </AccordionTrigger>
+            <AccordionContent>
+              Drag from an <strong>output</strong> (right side of a node) to an <strong>input</strong> (left side). Each input accepts one connection. Compatible signal types (e.g. HDMI, SCART, Component) are color-coded. Click the X on a connection to remove it.
+            </AccordionContent>
+          </AccordionItem>
+
+          <AccordionItem value="delete" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              How do I delete nodes or connections?
+            </AccordionTrigger>
+            <AccordionContent>
+              Select a node or connection, then press <kbd className="px-1.5 py-0.5 rounded bg-muted text-xs font-mono">Delete</kbd> or{" "}
+              <kbd className="px-1.5 py-0.5 rounded bg-muted text-xs font-mono">Backspace</kbd>. You can also click the X button on a node or on a selected connection. Multi-select first to delete several items at once.
+            </AccordionContent>
+          </AccordionItem>
+
+          <AccordionItem value="zoom-pan" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              How do I zoom and pan the canvas?
+            </AccordionTrigger>
+            <AccordionContent>
+              Scroll to zoom in and out. Click and drag on empty canvas to pan. The controls in the bottom-left (zoom in, zoom out, fit view) provide quick shortcuts. Fit view is especially useful after loading a diagram.
+            </AccordionContent>
+          </AccordionItem>
+
+          <AccordionItem value="save-load" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              How do I save and load my diagrams?
+            </AccordionTrigger>
+            <AccordionContent>
+              <strong>Save:</strong> Click &quot;Save Setup&quot; to save your diagram as a JSON file. <strong>Load:</strong> Click &quot;Load&quot; to open a previously saved file. Recent diagrams appear on the home page for quick access.
+            </AccordionContent>
+          </AccordionItem>
+
+          <AccordionItem value="examples" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              Can I try example diagrams?
+            </AccordionTrigger>
+            <AccordionContent>
+              Yes! Use the &quot;Examples&quot; dropdown in the editor to load pre-built setups (Simple, Medium, Advanced, SVS, Silly creator setup). These are great for inspiration or as a starting point.
+            </AccordionContent>
+          </AccordionItem>
+
+          <AccordionItem value="output-types" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              How do I change output types on consoles or switches?
+            </AccordionTrigger>
+            <AccordionContent>
+              Many consoles and switches support multiple output types (e.g. RGB SCART, Component, HDMI). Click the settings/cog icon on a node to open its options and select the output type. The connection colors update to match the signal type.
+            </AccordionContent>
+          </AccordionItem>
+
+          <AccordionItem value="sidebar" className="border border-border rounded-lg px-4">
+            <AccordionTrigger className="hover:no-underline">
+              How do I add components to the diagram?
+            </AccordionTrigger>
+            <AccordionContent>
+              Drag components from the left sidebar onto the canvas. Use the search box to filter by name. Components are grouped by category: consoles (by maker), switches, displays, adapters, upscalers, and custom items.
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+
+        <p className="text-sm text-muted-foreground mt-12 text-center">
+          Still have questions? Check the{" "}
+          <a
+            href="https://github.com/jonasrosland/retrogamecabling"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            project documentation
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "wouter";
-import { Plus, Trash2, Calendar, FileText, Cpu } from "lucide-react";
+import { Plus, Trash2, Calendar, FileText, Cpu, HelpCircle } from "lucide-react";
 import { APP_VERSION } from "@/config";
 import { Button } from "@/components/ui/button";
 import { format } from "date-fns";
@@ -54,6 +54,15 @@ export default function Home() {
               >
                 <Plus className="mr-2 h-5 w-5" />
                 New Diagram
+              </Button>
+              <Button 
+                size="lg" 
+                onClick={() => setLocation('/faq')}
+                variant="outline"
+                className="border-border bg-background/50 hover:bg-muted text-lg px-8 py-6 h-auto shadow-[0_0_20px_rgba(6,182,212,0.3)] hover:shadow-[0_0_30px_rgba(6,182,212,0.4)] transition-all"
+              >
+                <HelpCircle className="mr-2 h-5 w-5" />
+                FAQ
               </Button>
               <Button 
                 size="lg" 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,16 @@ services:
       - /app/node_modules
     command: npm run dev
 
+  # caddy:
+  #   image: caddy:latest
+  #   restart: unless-stopped
+  #   ports:
+  #     - "80:80"
+  #     - "443:443"
+  #     - "443:443/udp"
+  #   volumes:
+  #     - ./caddy/conf:/etc/caddy
+  #     - ./caddy/site:/srv
+  #     - ./caddy/caddy_data:/data
+  #     - ./caddy/caddy_config:/config
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "retro-game-cabling",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "retro-game-cabling",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@jridgewell/trace-mapping": "^0.3.25",
+        "@msgpack/msgpack": "^3.1.1",
         "@radix-ui/react-accordion": "^1.2.4",
         "@radix-ui/react-alert-dialog": "^1.1.7",
         "@radix-ui/react-aspect-ratio": "^1.1.3",
@@ -1558,6 +1559,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@poppinss/colors": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retro-game-cabling",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "engines": {
@@ -15,6 +15,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@jridgewell/trace-mapping": "^0.3.25",
+    "@msgpack/msgpack": "^3.1.1",
     "@radix-ui/react-accordion": "^1.2.4",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-aspect-ratio": "^1.1.3",


### PR DESCRIPTION
Bump package version to 1.2.0. Add ccc2 share wire (MessagePack + gzip), catalog itemId + delta encoding, share dialog with code and URL copy, hash import, and catalogNodeDefaults. Include FAQ route, dialog UI, and related app/navigation updates.